### PR TITLE
Add theme-aware logo and service pricing pages

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,24 +1,35 @@
 import { Link, NavLink } from 'react-router-dom';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Menu, X } from 'lucide-react';
-import logo from '../assets/MWM-logo-light-mode.png';
+import logoLight from '../assets/MWM-logo-light-mode.png';
+import logoDark from '../assets/MWM-logo-dark-mode.png';
 import ThemeToggle from './ThemeToggle';
 
 export default function Header() {
   const [open, setOpen] = useState(false);
+  const [theme, setTheme] = useState(
+    () => document.documentElement.dataset.theme || 'light',
+  );
+  useEffect(() => {
+    const handler = (e) => setTheme(e.detail);
+    window.addEventListener('themechange', handler);
+    return () => window.removeEventListener('themechange', handler);
+  }, []);
   const nav = [
     { to: '/services', label: 'Services' },
     { to: '/work', label: 'Work' },
     { to: '/process', label: 'Process' },
-    { to: '/pricing', label: 'Pricing' },
-    { to: '/upgive', label: 'UpGive' },
     { to: '/contact', label: 'Contact' },
   ];
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-bg/80 backdrop-blur border-b border-border">
       <div className="max-w-6xl mx-auto flex items-center justify-between px-4 h-16">
         <Link to="/" className="flex items-center gap-2">
-          <img src={logo} alt="Media with a Mission" className="h-8 w-auto" />
+          <img
+            src={theme === 'dark' ? logoDark : logoLight}
+            alt="Media with a Mission"
+            className="h-8 w-auto"
+          />
         </Link>
         <nav className="hidden md:flex gap-6">
           {nav.map((n) => (

--- a/src/components/OrbsBackground.jsx
+++ b/src/components/OrbsBackground.jsx
@@ -23,7 +23,7 @@ export default function OrbsBackground() {
                   y: [0, -20, 0],
                 }
           }
-          transition={{ repeat: Infinity, duration: o.duration }}
+          transition={{ repeat: Infinity, duration: o.duration, repeatType: 'reverse' }}
         />
       ))}
     </div>

--- a/src/components/ThemeToggle.jsx
+++ b/src/components/ThemeToggle.jsx
@@ -13,6 +13,7 @@ export default function ThemeToggle() {
   useEffect(() => {
     document.documentElement.dataset.theme = theme;
     localStorage.setItem('theme', theme);
+    window.dispatchEvent(new CustomEvent('themechange', { detail: theme }));
   }, [theme]);
 
   const toggle = () => setTheme(theme === 'light' ? 'dark' : 'light');

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,9 +1,25 @@
 import { Link } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import Button from '../components/ui/Button';
 import OrbsBackground from '../components/OrbsBackground';
+import logoLight from '../assets/MWM-logo-light-mode.png';
+import logoDark from '../assets/MWM-logo-dark-mode.png';
 
 export default function Home() {
-  const showMission = true; // toggle to show mission statement vs boilerplate
+  const [theme, setTheme] = useState(
+    () => document.documentElement.dataset.theme || 'light',
+  );
+  const [scrolled, setScrolled] = useState(false);
+  useEffect(() => {
+    const handler = (e) => setTheme(e.detail);
+    window.addEventListener('themechange', handler);
+    const onScroll = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', onScroll);
+    return () => {
+      window.removeEventListener('themechange', handler);
+      window.removeEventListener('scroll', onScroll);
+    };
+  }, []);
   const services = [
     {
       title: 'Story-Driven Video',
@@ -18,7 +34,7 @@ export default function Home() {
     {
       title: 'UpGive: Event Giving Display',
       tagline: 'Gamified giving displays for events.',
-      href: '/upgive',
+      href: '/services/upgive',
     },
   ];
   const showcase = [
@@ -38,47 +54,58 @@ export default function Home() {
       image: 'https://picsum.photos/seed/3/400/300',
     },
   ];
+  const logoSrc = theme === 'dark' ? logoDark : logoLight;
   return (
     <div>
       <section className="relative overflow-hidden py-32 text-center">
         <OrbsBackground />
+        <img
+          src={logoSrc}
+          alt="Media with a Mission"
+          className={
+            scrolled
+              ? 'fixed top-4 right-4 w-16 z-50 transition-all duration-300'
+              : 'mx-auto mb-6 w-64 transition-all duration-300'
+          }
+        />
         <div className="relative z-10 space-y-6 px-4">
-          {showMission ? (
-            <h1 className="text-5xl font-display font-bold">
-              Storytelling for Impact
-            </h1>
-          ) : (
-            <p className="max-w-xl mx-auto text-lg text-muted">
-              Media with a Mission partners with nonprofits to amplify change
-              through cinematic video and web tools.
-            </p>
-          )}
+          <h1 className="text-5xl font-display font-bold">
+            Storytelling for Impact
+          </h1>
+          <p className="max-w-xl mx-auto text-lg text-muted">
+            Media with a Mission partners with nonprofits to amplify change
+            through cinematic video and web tools.
+          </p>
           <Button as={Link} to="/contact" variant="primary">
             Start a Project
           </Button>
         </div>
       </section>
-      <div aria-hidden="true" className="h-16 bg-brand -skew-y-1" />
-      <section className="py-24 px-4 text-center max-w-6xl mx-auto" id="services">
-        <h2 className="text-4xl font-display mb-2">Services</h2>
-        <p className="text-muted mb-8">How we can help.</p>
-        <div className="grid gap-6 sm:grid-cols-3 text-left">
-          {services.map((s) => (
-            <div
-              key={s.title}
-              className="bg-card border border-border rounded-lg p-6 flex flex-col"
-            >
-              <h3 className="text-xl font-semibold mb-2">{s.title}</h3>
-              <p className="text-muted flex-grow">{s.tagline}</p>
-              <Button
-                as={Link}
-                to={s.href}
-                className="mt-4 transform transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+      <section
+        className="py-24 px-4 text-center bg-brand text-brand-ink"
+        id="services"
+      >
+        <div className="max-w-6xl mx-auto">
+          <h2 className="text-4xl font-display mb-2">Services</h2>
+          <p className="mb-8">How we can help.</p>
+          <div className="grid gap-6 sm:grid-cols-3 text-left">
+            {services.map((s) => (
+              <div
+                key={s.title}
+                className="bg-card border border-border rounded-lg p-6 flex flex-col"
               >
-                Learn More
-              </Button>
-            </div>
-          ))}
+                <h3 className="text-xl font-semibold mb-2">{s.title}</h3>
+                <p className="text-muted flex-grow">{s.tagline}</p>
+                <Button
+                  as={Link}
+                  to={s.href}
+                  className="mt-4 transform transition-transform hover:scale-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                >
+                  Learn More
+                </Button>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
       <section className="py-24 px-4 bg-surface">

--- a/src/pages/Services.jsx
+++ b/src/pages/Services.jsx
@@ -6,14 +6,17 @@ const data = {
   'Story-Driven Video': {
     desc: 'Short films that move people to act.',
     bullets: ['Raise awareness', 'Boost donations', 'Share your mission'],
+    pricing: '/pricing/video',
   },
   'Web Tools & Sites': {
     desc: 'Squarespace or Next.js sites focused on outcomes.',
     bullets: ['Fast launch', 'Metrics tracking', 'Flexible CMS'],
+    pricing: '/pricing/web',
   },
   'UpGive: Event Giving Display': {
     desc: 'Gamified giving displays for events.',
     bullets: ['Real-time tally', 'Leaderboards', 'Audience engagement'],
+    pricing: '/pricing/upgive',
   },
 };
 
@@ -31,6 +34,9 @@ export default function Services() {
             <li key={b}>{b}</li>
           ))}
         </ul>
+        <Button as="a" href={current.pricing} variant="secondary">
+          See Pricing
+        </Button>
         <Button as="a" href="/contact">Start a Project</Button>
       </div>
     </section>

--- a/src/pages/pricing/UpGive.jsx
+++ b/src/pages/pricing/UpGive.jsx
@@ -1,0 +1,26 @@
+import Card from '../../components/ui/Card';
+
+export default function UpGivePricing() {
+  return (
+    <section className="max-w-3xl mx-auto py-24 px-4 space-y-8">
+      <h1 className="text-4xl font-display text-center mb-8">UpGive Pricing</h1>
+      <div className="grid md:grid-cols-3 gap-6">
+        <Card>
+          <h3 className="font-semibold mb-2">Event Display</h3>
+          <p className="text-3xl font-bold mb-4">$2k</p>
+          <p className="text-muted text-sm">Single-screen leaderboard.</p>
+        </Card>
+        <Card>
+          <h3 className="font-semibold mb-2">Campaign Package</h3>
+          <p className="text-3xl font-bold mb-4">$3k</p>
+          <p className="text-muted text-sm">Display plus live support.</p>
+        </Card>
+        <Card>
+          <h3 className="font-semibold mb-2">Custom</h3>
+          <p className="text-3xl font-bold mb-4">Let's chat</p>
+          <p className="text-muted text-sm">Tailored event integrations.</p>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/pricing/Video.jsx
+++ b/src/pages/pricing/Video.jsx
@@ -1,0 +1,26 @@
+import Card from '../../components/ui/Card';
+
+export default function VideoPricing() {
+  return (
+    <section className="max-w-3xl mx-auto py-24 px-4 space-y-8">
+      <h1 className="text-4xl font-display text-center mb-8">Video Pricing</h1>
+      <div className="grid md:grid-cols-3 gap-6">
+        <Card>
+          <h3 className="font-semibold mb-2">Mini Documentary</h3>
+          <p className="text-3xl font-bold mb-4">$10k</p>
+          <p className="text-muted text-sm">3-5 minute storytelling film.</p>
+        </Card>
+        <Card>
+          <h3 className="font-semibold mb-2">Campaign Package</h3>
+          <p className="text-3xl font-bold mb-4">$15k</p>
+          <p className="text-muted text-sm">Multiple edits for omnichannel use.</p>
+        </Card>
+        <Card>
+          <h3 className="font-semibold mb-2">Custom</h3>
+          <p className="text-3xl font-bold mb-4">Let's chat</p>
+          <p className="text-muted text-sm">Tailored for your mission.</p>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/pricing/Web.jsx
+++ b/src/pages/pricing/Web.jsx
@@ -1,0 +1,26 @@
+import Card from '../../components/ui/Card';
+
+export default function WebPricing() {
+  return (
+    <section className="max-w-3xl mx-auto py-24 px-4 space-y-8">
+      <h1 className="text-4xl font-display text-center mb-8">Web Tools & Sites Pricing</h1>
+      <div className="grid md:grid-cols-3 gap-6">
+        <Card>
+          <h3 className="font-semibold mb-2">Squarespace Clone</h3>
+          <p className="text-3xl font-bold mb-4">$5k</p>
+          <p className="text-muted text-sm">Adapt our proven template.</p>
+        </Card>
+        <Card>
+          <h3 className="font-semibold mb-2">Squarespace Rebuild</h3>
+          <p className="text-3xl font-bold mb-4">$7.5k</p>
+          <p className="text-muted text-sm">Refresh with custom tweaks.</p>
+        </Card>
+        <Card>
+          <h3 className="font-semibold mb-2">Custom</h3>
+          <p className="text-3xl font-bold mb-4">Let's chat</p>
+          <p className="text-muted text-sm">Next.js apps & more.</p>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -10,16 +10,22 @@ const CaseStudy = lazy(() => import('./pages/CaseStudy'));
 const Process = lazy(() => import('./pages/Process'));
 const Pricing = lazy(() => import('./pages/Pricing'));
 const Contact = lazy(() => import('./pages/Contact'));
+const VideoPricing = lazy(() => import('./pages/pricing/Video'));
+const WebPricing = lazy(() => import('./pages/pricing/Web'));
+const UpGivePricing = lazy(() => import('./pages/pricing/UpGive'));
 
 export const routes = [
   { path: '/', element: <Home /> },
   { path: '/services', element: <Services /> },
   { path: '/services/video', element: <Video /> },
   { path: '/services/web', element: <Web /> },
-  { path: '/upgive', element: <UpGive /> },
+  { path: '/services/upgive', element: <UpGive /> },
   { path: '/work', element: <Work /> },
   { path: '/work/:slug', element: <CaseStudy /> },
   { path: '/process', element: <Process /> },
   { path: '/pricing', element: <Pricing /> },
+  { path: '/pricing/video', element: <VideoPricing /> },
+  { path: '/pricing/web', element: <WebPricing /> },
+  { path: '/pricing/upgive', element: <UpGivePricing /> },
   { path: '/contact', element: <Contact /> },
 ];


### PR DESCRIPTION
## Summary
- Swap logo based on active theme and trim navigation items
- Expand home hero with large logo, mission copy, and full-width services section
- Add individual pricing pages with routing for video, web, and UpGive services
- Repair animated orbs background

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898da48f2248321878ac43fc3491251