### PR TITLE
Animate home logo into navbar on scroll

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,21 +1,30 @@
-
 import { useEffect, useState } from 'react';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
 import logoLight from '../assets/MWM-logo-light-mode.png';
 import logoDark from '../assets/MWM-logo-dark-mode.png';
 import ThemeToggle from './ThemeToggle';
 
 export default function Header() {
+  const location = useLocation();
   const [open, setOpen] = useState(false);
   const [theme, setTheme] = useState(
     () => document.documentElement.dataset.theme || 'light',
   );
-  
+  const [scrolled, setScrolled] = useState(false);
+
   useEffect(() => {
     const handler = (e) => setTheme(e.detail);
     window.addEventListener('themechange', handler);
-    return () => window.removeEventListener('themechange', handler);
+    const onScroll = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', onScroll);
+    return () => {
+      window.removeEventListener('themechange', handler);
+      window.removeEventListener('scroll', onScroll);
+    };
   }, []);
+
+  const showLogo = scrolled || location.pathname !== '/';
   const nav = [
     { to: '/services', label: 'Services' },
     { to: '/work', label: 'Work' },
@@ -25,6 +34,12 @@ export default function Header() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-bg/80 backdrop-blur border-b border-border">
       <div className="max-w-6xl mx-auto flex items-center justify-between px-4 h-16">
+        <Link
+          to="/"
+          className={`block transition-opacity duration-300 ${
+            showLogo ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          }`}
+        >
           <img
             src={theme === 'dark' ? logoDark : logoLight}
             alt="Media with a Mission"

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -57,6 +57,15 @@ export default function Home() {
   const logoSrc = theme === 'dark' ? logoDark : logoLight;
   return (
     <div>
+      <img
+        src={logoSrc}
+        alt="Media with a Mission"
+        className={`fixed z-40 transition-all duration-500 transform ${
+          scrolled
+            ? 'top-3 left-3 w-8 opacity-0 pointer-events-none'
+            : 'top-1/2 left-1/2 w-48 -translate-x-1/2 -translate-y-1/2 opacity-100'
+        }`}
+      />
       <section className="relative overflow-hidden py-32 text-center">
         <OrbsBackground />
         <div className="relative z-10 space-y-6 px-4">


### PR DESCRIPTION
## Summary
- Animate home logo to shrink and move to the top-left on scroll
- Hide header logo until scrolled or when not on the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a321f5d048321ad8a1e8dac7a732a