### PR TITLE
Animate home logo into navbar on scroll

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,21 +1,26 @@
-
 import { useEffect, useState } from 'react';
+import { Link, NavLink, useLocation } from 'react-router-dom';
 import { Menu, X } from 'lucide-react';
 import logoLight from '../assets/MWM-logo-light-mode.png';
 import logoDark from '../assets/MWM-logo-dark-mode.png';
 import ThemeToggle from './ThemeToggle';
+import useTheme from '../hooks/useTheme';
 
 export default function Header() {
+  const location = useLocation();
   const [open, setOpen] = useState(false);
-  const [theme, setTheme] = useState(
-    () => document.documentElement.dataset.theme || 'light',
-  );
-  
+  const theme = useTheme();
+  const [scrolled, setScrolled] = useState(false);
+
   useEffect(() => {
-    const handler = (e) => setTheme(e.detail);
-    window.addEventListener('themechange', handler);
-    return () => window.removeEventListener('themechange', handler);
+    const onScroll = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+    };
   }, []);
+
+  const showLogo = scrolled || location.pathname !== '/';
   const nav = [
     { to: '/services', label: 'Services' },
     { to: '/work', label: 'Work' },
@@ -25,7 +30,14 @@ export default function Header() {
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-bg/80 backdrop-blur border-b border-border">
       <div className="max-w-6xl mx-auto flex items-center justify-between px-4 h-16">
+        <Link
+          to="/"
+          className={`block transition-opacity duration-300 ${
+            showLogo ? 'opacity-100' : 'opacity-0 pointer-events-none'
+          }`}
+        >
           <img
+            id="navbar-logo"
             src={theme === 'dark' ? logoDark : logoLight}
             alt="Media with a Mission"
             className="h-8 w-auto"

--- a/src/hooks/useTheme.js
+++ b/src/hooks/useTheme.js
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+export default function useTheme() {
+  const [theme, setTheme] = useState(
+    () => document.documentElement.dataset.theme || 'light',
+  );
+
+  useEffect(() => {
+    const handler = (e) => setTheme(e.detail);
+    window.addEventListener('themechange', handler);
+    return () => window.removeEventListener('themechange', handler);
+  }, []);
+
+  return theme;
+}


### PR DESCRIPTION
## Summary
- Animate home logo to shrink and move to the top-left on scroll
- Hide header logo until scrolled or when not on the home page
- Use shared theme hook so logos stay in sync in light and dark mode
- Position hero logo above intro content and tween it exactly into the navbar

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a321f5d048321ad8a1e8dac7a732a