### PR TITLE
fix: restore header and home layout

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -9,6 +9,13 @@ import useTheme from '../hooks/useTheme';
 export default function Header() {
   const location = useLocation();
   const [open, setOpen] = useState(false);
+  const theme = useTheme();
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => setScrolled(window.scrollY > 50);
+    window.addEventListener('scroll', onScroll);
+    return () => {
       window.removeEventListener('scroll', onScroll);
     };
   }, []);

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -87,6 +87,7 @@ export default function Home() {
   const logoSrc = theme === 'dark' ? logoDark : logoLight;
   return (
     <div>
+      <section className="relative overflow-hidden pt-32 pb-32 text-center">
         <OrbsBackground />
         <div className="relative z-10 flex flex-col items-center space-y-6 px-4">
           <div


### PR DESCRIPTION
## Summary
- restore header scroll/animation logic
- reinstate hero section wrapper and layout on home page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a365f69b4832187633f7671600fb4