### PR TITLE
feat: revamp hero logo and add angled about section

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -6,7 +6,7 @@ const Hero = forwardRef(function Hero({ title, subtitle }, ref) {
   return (
     <section
       ref={ref}
-      className="relative flex flex-col items-center justify-center min-h-screen text-center px-4 space-y-6"
+      className="relative flex flex-col items-center justify-start min-h-screen text-center px-4 space-y-6 pt-80"
     >
       <h1 className="text-4xl sm:text-5xl font-display font-bold max-w-3xl">
         {title}

--- a/src/components/LogoLockup.jsx
+++ b/src/components/LogoLockup.jsx
@@ -12,7 +12,7 @@ export default function LogoLockup() {
       aria-label="Media with a Mission"
       className="logo-lockup fixed z-50 transition-transform duration-300 ease-out"
     >
-      <img src={src} alt="Media with a Mission" className="w-64 h-auto" />
+      <img src={src} alt="Media with a Mission" className="w-96 h-auto" />
     </Link>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -29,7 +29,7 @@ export default function Home() {
           document.body.classList.add('logo-pinned');
         }
       },
-      { threshold: 0.1 }
+      { threshold: 0.9 }
     );
     observer.observe(heroRef.current);
     return () => observer.disconnect();
@@ -48,7 +48,7 @@ export default function Home() {
           </div>
         </div>
       </Section>
-      <Section>
+      <Section className="angled-section">
         <div className="max-w-3xl mx-auto text-center space-y-4">
           <h2 className="text-3xl font-display font-bold">About Us</h2>
           <p className="text-muted text-lg">{site.about}</p>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -18,9 +18,9 @@
 
 /* logo lockup transition */
 .logo-lockup {
-  top: 50%;
+  top: 2rem;
   left: 50%;
-  transform: translate(-50%, -50%) scale(1);
+  transform: translateX(-50%) scale(1);
   transform-origin: top left;
 }
 
@@ -45,19 +45,54 @@ body.logo-pinned .logo-lockup {
   transition: opacity var(--transition), transform var(--transition);
   z-index: 100;
 }
-.toast.show {
-  opacity: 1;
-  transform: translateX(-50%) translateY(0);
-}
+  .toast.show {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
 .toast-success {
   border-color: var(--ok);
 }
-.toast-error {
-  border-color: var(--danger);
+  .toast-error {
+    border-color: var(--danger);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .toast {
+      transition: none;
+    }
+  }
+
+/* angled yellow section */
+.angled-section {
+  position: relative;
+  overflow: hidden;
+  color: var(--brand-ink);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  .toast {
-    transition: none;
-  }
+.angled-section::before,
+.angled-section::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 150%;
+  transform: skewY(-25deg);
+  transform-origin: top left;
+  z-index: -1;
+}
+
+.angled-section::before {
+  top: -25%;
+  background: var(--brand);
+}
+
+.angled-section::after {
+  top: calc(-25% + 4px);
+  background: var(--surface);
+  transform: skewY(-25deg) translateX(-100%);
+  transition: transform 0.5s var(--transition);
+}
+
+.angled-section:hover::after {
+  transform: skewY(-25deg) translateX(0);
 }


### PR DESCRIPTION
## Summary
- enlarge and reposition hero logo to top center and snap faster on scroll
- add angled yellow about section with swipe fill hover animation

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a6f4092648321b799837fddb8e487