### PR TITLE
Adjust navbar and angled services section

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -17,8 +17,8 @@ export default function Header() {
   const nav = navItems;
   return (
     <header className="fixed top-0 left-0 right-0 z-40 bg-bg/80 backdrop-blur border-b border-border">
-      <div className="max-w-6xl mx-auto flex items-center justify-between px-4 h-16">
-        <div className="w-32 h-8" aria-hidden="true" />
+      <div className="max-w-6xl mx-auto flex items-center justify-between px-4 h-24">
+        <div className="w-28 h-24" aria-hidden="true" />
         <nav className="hidden md:flex gap-6">
           {nav.map((n) => (
             <NavLink

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -38,7 +38,7 @@ export default function Home() {
   return (
     <div>
       <Hero ref={heroRef} title={site.hero.headline} subtitle={site.hero.subtext} />
-      <Section className="bg-surface">
+      <Section className="angled-section">
         <div className="max-w-6xl mx-auto">
           <h2 className="text-3xl font-display font-bold text-center mb-10">Services</h2>
           <div className="grid gap-6 md:grid-cols-3">

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -25,9 +25,9 @@
 }
 
 body.logo-pinned .logo-lockup {
-  top: 0.75rem;
+  top: 0;
   left: 1rem;
-  transform: translate(0, 0) scale(0.4);
+  transform: translate(0, 0) scale(0.25);
 }
 
 .toast {
@@ -67,6 +67,7 @@ body.logo-pinned .logo-lockup {
   position: relative;
   overflow: hidden;
   color: var(--brand-ink);
+  transition: color var(--transition);
 }
 
 .angled-section::before,
@@ -87,7 +88,7 @@ body.logo-pinned .logo-lockup {
 }
 
 .angled-section::after {
-  top: calc(-25% + 4px);
+  top: calc(-25% + 3px);
   background: var(--surface);
   transform: skewY(-25deg) translateX(-100%);
   transition: transform 0.5s var(--transition);
@@ -95,4 +96,8 @@ body.logo-pinned .logo-lockup {
 
 .angled-section:hover::after {
   transform: skewY(-25deg) translateX(0);
+}
+
+.angled-section:hover {
+  color: var(--text);
 }


### PR DESCRIPTION
## Summary
- scale logo into the navbar and raise header height
- add angled background with hover animation to services section
- leave thin brand divider and shift text colors for dark mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a725f4b488321818ae2967385d10a