### PR TITLE
feat: redesign home services section with diagonal sweep

### DIFF
--- a/src/components/ServicesSection.css
+++ b/src/components/ServicesSection.css
@@ -1,0 +1,55 @@
+.services-section {
+  --slant: 2rem;
+  position: relative;
+  overflow: hidden;
+  color: var(--text);
+  transition: color var(--transition);
+}
+.services-section > * {
+  position: relative;
+  z-index: 2;
+}
+.services-section::before,
+.services-section::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  clip-path: polygon(0 0, 100% var(--slant), 100% 100%, 0 100%);
+}
+.services-section::before {
+  background: var(--services-base);
+  z-index: 0;
+}
+.services-section::after {
+  background: var(--services-sweep);
+  clip-path: polygon(0 3px, 100% calc(var(--slant) + 3px), 100% 100%, 0 100%);
+  transform: translateX(-100%);
+  transition: transform 0.5s var(--transition);
+  z-index: 1;
+}
+.services-section:hover,
+.services-section:focus-within {
+  color: var(--brand-ink);
+}
+.services-section:hover::after,
+.services-section:focus-within::after {
+  transform: translateX(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .services-section::after {
+    transition: none;
+    transform: translateX(0);
+  }
+}
+@media (min-width: 768px) {
+  .services-section {
+    --slant: 3rem;
+  }
+}
+@media (min-width: 1024px) {
+  .services-section {
+    --slant: 4rem;
+  }
+}

--- a/src/components/ServicesSection.jsx
+++ b/src/components/ServicesSection.jsx
@@ -1,0 +1,19 @@
+import services from '../assets/data/services.json';
+import Section from './Section';
+import ServiceCard from './ServiceCard';
+import './ServicesSection.css';
+
+export default function ServicesSection() {
+  return (
+    <Section className="services-section">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-3xl font-display font-bold text-center mb-10">Services</h2>
+        <div className="grid gap-6 md:grid-cols-3">
+          {services.map((s) => (
+            <ServiceCard key={s.slug} title={s.title} excerpt={s.excerpt} slug={s.slug} />
+          ))}
+        </div>
+      </div>
+    </Section>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,7 +3,7 @@ import services from '../assets/data/services.json';
 import site from '../assets/data/site.json';
 import Hero from '../components/Hero';
 import Section from '../components/Section';
-import ServiceCard from '../components/ServiceCard';
+import ServicesSection from '../components/ServicesSection';
 import CTA from '../components/CTA';
 import usePageMeta from '../hooks/usePageMeta';
 
@@ -38,17 +38,8 @@ export default function Home() {
   return (
     <div>
       <Hero ref={heroRef} title={site.hero.headline} subtitle={site.hero.subtext} />
-      <Section className="angled-section">
-        <div className="max-w-6xl mx-auto">
-          <h2 className="text-3xl font-display font-bold text-center mb-10">Services</h2>
-          <div className="grid gap-6 md:grid-cols-3">
-            {services.map((s) => (
-              <ServiceCard key={s.slug} title={s.title} excerpt={s.excerpt} slug={s.slug} />
-            ))}
-          </div>
-        </div>
-      </Section>
-      <Section className="angled-section">
+      <ServicesSection />
+      <Section>
         <div className="max-w-3xl mx-auto text-center space-y-4">
           <h2 className="text-3xl font-display font-bold">About Us</h2>
           <p className="text-muted text-lg">{site.about}</p>

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -22,12 +22,14 @@
   left: 50%;
   transform: translateX(-50%) scale(1);
   transform-origin: top left;
+  pointer-events: none;
 }
 
 body.logo-pinned .logo-lockup {
   top: 0;
   left: 1rem;
   transform: translate(0, 0) scale(0.25);
+  pointer-events: auto;
 }
 
 .toast {
@@ -61,43 +63,3 @@ body.logo-pinned .logo-lockup {
       transition: none;
     }
   }
-
-/* angled yellow section */
-.angled-section {
-  position: relative;
-  overflow: hidden;
-  color: var(--brand-ink);
-  transition: color var(--transition);
-}
-
-.angled-section::before,
-.angled-section::after {
-  content: '';
-  position: absolute;
-  left: 0;
-  width: 100%;
-  height: 150%;
-  transform: skewY(-25deg);
-  transform-origin: top left;
-  z-index: -1;
-}
-
-.angled-section::before {
-  top: -25%;
-  background: var(--brand);
-}
-
-.angled-section::after {
-  top: calc(-25% + 3px);
-  background: var(--surface);
-  transform: skewY(-25deg) translateX(-100%);
-  transition: transform 0.5s var(--transition);
-}
-
-.angled-section:hover::after {
-  transform: skewY(-25deg) translateX(0);
-}
-
-.angled-section:hover {
-  color: var(--text);
-}

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,6 +1,8 @@
 :root {
   color-scheme: light dark;
   --transition: 200ms ease-in-out;
+  --services-base: var(--surface);
+  --services-sweep: var(--brand);
 }
 
 [data-theme='light'] {
@@ -15,6 +17,8 @@
   --ok: #34d399;
   --info: #60a5fa;
   --danger: #f87171;
+  --services-base: var(--surface);
+  --services-sweep: var(--brand);
 }
 
 [data-theme='dark'] {
@@ -29,6 +33,8 @@
   --ok: #34d399;
   --info: #60a5fa;
   --danger: #f87171;
+  --services-base: var(--card);
+  --services-sweep: var(--brand);
 }
 
 html {


### PR DESCRIPTION
## Summary
- replace home services block with new `ServicesSection` component
- add diagonal background with left-to-right sweep and theme vars
- allow navigation click-through during logo intro animation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a76d88e5883218188b45ccb4ad33a