### PR TITLE
Sharpen services section sweep

### DIFF
--- a/src/components/ServicesSection.css
+++ b/src/components/ServicesSection.css
@@ -23,10 +23,14 @@
   z-index: 0;
 }
 .services-section::after {
-  background: var(--services-sweep);
-  clip-path: polygon(0 3px, 100% calc(var(--slant) + 3px), 100% 100%, 0 100%);
+  background: linear-gradient(
+    to right,
+    transparent calc(100% - 4px),
+    var(--services-sweep) calc(100% - 4px)
+  );
+  clip-path: polygon(0 0, 100% var(--slant), 100% 100%, 0 100%);
   transform: translateX(-100%);
-  transition: transform 0.5s var(--transition);
+  transition: transform 150ms ease-out;
   z-index: 1;
 }
 .services-section:hover,


### PR DESCRIPTION
## Summary
- Change services overlay to a thin vertical gradient for a sharp left-to-right swipe
- Accelerate the sweep animation for a quicker transition

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a7aad13e883219cae466e038be711