### PR TITLE
Improve logo transition and add subtle animations

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -16,7 +16,7 @@ export default function Header() {
 
   const nav = navItems;
   return (
-    <header className="fixed top-0 left-0 right-0 z-40 bg-bg/80 backdrop-blur border-b border-border">
+    <header className="fixed top-0 left-0 right-0 z-40 bg-bg/80 backdrop-blur border-b border-border shadow-md">
       <div className="max-w-6xl mx-auto flex items-center justify-between px-4 h-24">
         <div className="w-28 h-24" aria-hidden="true" />
         <nav className="hidden md:flex gap-6">
@@ -25,7 +25,9 @@ export default function Header() {
               key={n.path}
               to={n.path}
               className={({ isActive }) =>
-                `hover:text-brand ${isActive ? 'text-brand' : 'text-muted'}`
+                `hover:text-brand transition-colors ${
+                  isActive ? 'text-brand' : 'text-muted'
+                }`
               }
             >
               {n.label}

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -8,11 +8,15 @@ const Hero = forwardRef(function Hero({ title, subtitle }, ref) {
       ref={ref}
       className="relative flex flex-col items-center justify-start min-h-screen text-center px-4 space-y-6 pt-80"
     >
-      <h1 className="text-4xl sm:text-5xl font-display font-bold max-w-3xl">
+      <h1 className="text-4xl sm:text-5xl font-display font-bold max-w-3xl glow animate-fade-in">
         {title}
       </h1>
-      <p className="max-w-2xl text-lg text-muted">{subtitle}</p>
-      <Button as={Link} to="/contact">Start a Project</Button>
+      <p className="max-w-2xl text-lg text-muted animate-fade-in animate-delay-200">
+        {subtitle}
+      </p>
+      <Button as={Link} to="/contact" className="animate-fade-in animate-delay-400">
+        Start a Project
+      </Button>
     </section>
   );
 });

--- a/src/components/LogoLockup.jsx
+++ b/src/components/LogoLockup.jsx
@@ -12,7 +12,7 @@ export default function LogoLockup() {
       aria-label="Media with a Mission"
       className="logo-lockup fixed z-50 transition-transform duration-300 ease-out"
     >
-      <img src={src} alt="Media with a Mission" className="w-96 h-auto" />
+      <img src={src} alt="Media with a Mission" className="w-96 h-auto glow" />
     </Link>
   );
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -21,6 +21,13 @@ export default function Home() {
       document.body.classList.add('logo-pinned');
       return;
     }
+    const hero = heroRef.current;
+    const heading = hero.querySelector('h1');
+    const logo = document.querySelector('.logo-lockup img');
+    const offset =
+      heading && logo
+        ? heading.offsetTop - logo.getBoundingClientRect().height - 16
+        : 0;
     const observer = new IntersectionObserver(
       ([entry]) => {
         if (entry.isIntersecting) {
@@ -29,9 +36,9 @@ export default function Home() {
           document.body.classList.add('logo-pinned');
         }
       },
-      { threshold: 0.9 }
+      { rootMargin: `-${offset}px 0px 0px 0px` }
     );
-    observer.observe(heroRef.current);
+    observer.observe(hero);
     return () => observer.disconnect();
   }, []);
 

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -63,3 +63,30 @@ body.logo-pinned .logo-lockup {
       transition: none;
     }
   }
+
+@layer utilities {
+  .glow {
+    filter: drop-shadow(0 0 0.5rem var(--brand));
+  }
+  .animate-fade-in {
+    opacity: 0;
+    animation: fade-in 0.6s ease-out forwards;
+  }
+  .animate-delay-200 {
+    animation-delay: 0.2s;
+  }
+  .animate-delay-400 {
+    animation-delay: 0.4s;
+  }
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}


### PR DESCRIPTION
## Summary
- Trigger logo pin earlier to avoid overlap with hero text
- Add glow and fade-in utilities for animated elements
- Enhance header and hero with drop shadows and transitions

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689a7e7bff8c8321934c48fb475f1157