### PR TITLE
fix intersection observer margin calculation

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -26,7 +26,7 @@ export default function Home() {
     const logo = document.querySelector('.logo-lockup img');
     const offset =
       heading && logo
-        ? heading.offsetTop - logo.getBoundingClientRect().height - 16
+        ? Math.max(0, heading.offsetTop - logo.getBoundingClientRect().height - 16)
         : 0;
     const observer = new IntersectionObserver(
       ([entry]) => {
@@ -36,7 +36,7 @@ export default function Home() {
           document.body.classList.add('logo-pinned');
         }
       },
-      { rootMargin: `-${offset}px 0px 0px 0px` }
+      { rootMargin: `${-offset}px 0px 0px 0px` }
     );
     observer.observe(hero);
     return () => observer.disconnect();


### PR DESCRIPTION
## Summary
- clamp offset when computing rootMargin for IntersectionObserver so observer init doesn't fail

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a844cd1108321bb08d4933e92b57f