### PR TITLE
Refine logo pin timing and service hover

### DIFF
--- a/src/components/ServicesSection.css
+++ b/src/components/ServicesSection.css
@@ -42,7 +42,8 @@
   /* start off-screen, offset along slope so motion tracks the diagonal */
   transform: translate(-101%, calc(-1 * var(--slant)));
   transform-origin: left top;
-  transition: transform 100ms ease-in-out; /* faster, smooth in/out */
+  transition: transform 100ms cubic-bezier(0.4, 0, 0.2, 1);
+  will-change: transform;
   z-index: 1;
 }
 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -46,22 +46,34 @@ export default function Home() {
 
   useEffect(() => {
     document.body.classList.remove('logo-pinned');
-    if (!('IntersectionObserver' in window) || !heroRef.current) {
+    const heroEl = heroRef.current;
+    const heading = heroEl?.querySelector('h1');
+    const logo = document.querySelector('.logo-lockup');
+
+    if (!heroEl || !heading || !logo) {
       document.body.classList.add('logo-pinned');
       return;
     }
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          document.body.classList.remove('logo-pinned');
-        } else {
-          document.body.classList.add('logo-pinned');
-        }
-      },
-      { threshold: 0.9 }
-    );
-    observer.observe(heroRef.current);
-    return () => observer.disconnect();
+
+    // Calculate where the large logo ends so we can pin before overlap
+    const largeLogoBottom = logo.offsetTop + logo.offsetHeight;
+
+    const handleScroll = () => {
+      const headingTop = heading.getBoundingClientRect().top;
+      if (headingTop <= largeLogoBottom + 10) {
+        document.body.classList.add('logo-pinned');
+      } else {
+        document.body.classList.remove('logo-pinned');
+      }
+    };
+
+    handleScroll();
+    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('resize', handleScroll);
+    return () => {
+      window.removeEventListener('scroll', handleScroll);
+      window.removeEventListener('resize', handleScroll);
+    };
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- Pin homepage logo before the hero heading to avoid overlap
- Smooth service section hover animation with easing

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e81c403a08321a77f9fcfe2c8a089