### PR TITLE
Adjust logo resize trigger to track H1 content

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -9,7 +9,7 @@ const Hero = forwardRef(function Hero({ title, subtitle }, ref) {
       className="relative flex flex-col items-center justify-start min-h-screen text-center px-4 space-y-6 pt-80"
     >
       <h1 className="text-4xl sm:text-5xl font-display font-bold max-w-3xl">
-        {title}
+        <span className="hero-heading-content">{title}</span>
       </h1>
       <p className="max-w-2xl text-lg text-muted">{subtitle}</p>
       <Button as={Link} to="/contact">Start a Project</Button>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -49,17 +49,18 @@ export default function Home() {
     const heroEl = heroRef.current;
     const heading = heroEl?.querySelector('h1');
     const logo = document.querySelector('.logo-lockup');
+    const headingContent = heading?.querySelector('.hero-heading-content') || heading;
 
-    if (!heroEl || !heading || !logo) {
+    if (!heroEl || !headingContent || !logo) {
       document.body.classList.add('logo-pinned');
       return;
     }
 
     // Calculate where the large logo ends so we can pin before overlap
-    const largeLogoBottom = logo.offsetTop + logo.offsetHeight;
+    const largeLogoBottom = logo.getBoundingClientRect().bottom;
 
     const handleScroll = () => {
-      const headingTop = heading.getBoundingClientRect().top;
+      const headingTop = headingContent.getBoundingClientRect().top;
       if (headingTop <= largeLogoBottom + 10) {
         document.body.classList.add('logo-pinned');
       } else {


### PR DESCRIPTION
## Summary
- Wrap hero title text in a span to measure the exact text bounds
- Pin logo only when the heading's text approaches the logo's bottom edge

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689e84fd66fc83219d845791255880db