### PR TITLE
Avoid premature logo animation on home page

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -56,10 +56,8 @@ export default function Home() {
       return;
     }
 
-    // Calculate where the large logo ends so we can pin before overlap
-    const largeLogoBottom = logo.getBoundingClientRect().bottom;
-
     const handleScroll = () => {
+      const largeLogoBottom = logo.getBoundingClientRect().bottom;
       const headingTop = headingContent.getBoundingClientRect().top;
       if (headingTop <= largeLogoBottom + 10) {
         document.body.classList.add('logo-pinned');
@@ -68,12 +66,13 @@ export default function Home() {
       }
     };
 
-    handleScroll();
     window.addEventListener('scroll', handleScroll);
     window.addEventListener('resize', handleScroll);
+    window.addEventListener('load', handleScroll);
     return () => {
       window.removeEventListener('scroll', handleScroll);
       window.removeEventListener('resize', handleScroll);
+      window.removeEventListener('load', handleScroll);
     };
   }, []);
 


### PR DESCRIPTION
## Summary
- Recompute logo position on every scroll or resize and on window load
- Delay initial pinning until after the page fully loads to prevent early animation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e86de1aa88321a508f939a1a8f8ac